### PR TITLE
[NO-JIRA]: add long option aliases

### DIFF
--- a/list-cortex-repositories
+++ b/list-cortex-repositories
@@ -33,9 +33,9 @@ EOF
 # Ensure an option receives an accompanying value
 require_option_argument() {
   local option_name="$1"
-  local option_value="$2"
+  local option_value="${2-}"
 
-  if [[ -z "${option_value}" ]]; then
+  if [[ -z "${option_value}" || "${option_value}" == -* ]]; then
     echo "Error: Option ${option_name} requires an argument." >&2
     usage
     exit 2
@@ -46,18 +46,21 @@ require_option_argument() {
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -o|--owner-tag)
-      require_option_argument "$1" "${2-}"
-      OWNER_TAG="$2"
+      next_value="${2-}"
+      require_option_argument "$1" "${next_value}"
+      OWNER_TAG="${next_value}"
       shift 2
       ;;
     -f|--output-file)
-      require_option_argument "$1" "${2-}"
-      OUTPUT_FILE="$2"
+      next_value="${2-}"
+      require_option_argument "$1" "${next_value}"
+      OUTPUT_FILE="${next_value}"
       shift 2
       ;;
     -u|--base-url)
-      require_option_argument "$1" "${2-}"
-      BASE_URL="$2"
+      next_value="${2-}"
+      require_option_argument "$1" "${next_value}"
+      BASE_URL="${next_value}"
       shift 2
       ;;
     -q|--quiet)


### PR DESCRIPTION
## What?

Adds long-form command line options alongside the existing short flags in `list-cortex-repositories`.

## Why?

Provide a clearer, more discoverable interface for users who prefer full-word flags when running the script.

## Changes:

- Extend the usage help text to document both short and long option names.
- Replace the `getopts` loop with a manual parser that recognises `--owner-tag`, `--output-file`, `--base-url`, `--quiet`, and `--help`.
- Keep validation messages aligned with the new parsing logic.

## References:

- None
