### PR TITLE
[NO-JIRA]: add automated tests and ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install shellcheck and bats
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck bats
+
+      - name: Lint shell scripts
+        run: shellcheck list-cortex-repositories
+
+      - name: Run shell tests
+        run: bats tests

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,8 @@ setup: list-cortex-repositories
 uninstall:
 	sudo rm -f /usr/local/bin/list-cortex-repositories
 
-.PHONY: setup uninstall
+test:
+	shellcheck list-cortex-repositories
+	bats tests
+
+.PHONY: setup uninstall test

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 - Bash (tested with version 5)
 - `curl`
 - `jq`
+- `shellcheck` (for linting)
+- `bats` (for tests)
 - Network access to the Cortex Catalogue application programming interface endpoint used by your organisation
 
 Ensure these commands are installed and available on your command line interface before running the script.
@@ -61,3 +63,13 @@ The comma separated values file contains the columns `entity name`, `repo name`,
 - If the script reports `Error: required command ... not found`, install the missing command and retry.
 - If the script reports an authentication error, confirm that your token is valid and has Catalogue read permissions.
 - If the output file is empty, confirm that the owner tag exists in Cortex and that its entities have Git repository metadata set.
+
+## Testing
+
+The repository includes automated tests built with [shellcheck](https://www.shellcheck.net/) and [bats](https://bats-core.readthedocs.io/). To run them locally:
+
+```bash
+make test
+```
+
+The `make test` target lints the script with shellcheck and exercises the bats suite using stubbed Cortex responses, so no real Cortex API token is required.

--- a/tests/bin/curl
+++ b/tests/bin/curl
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE_DIR="${SCRIPT_DIR}/../fixtures"
+
+fail_on_page="${CURL_STUB_FAIL_ON_PAGE:-}"
+url=""
+
+args=("$@")
+while (($#)); do
+  case "$1" in
+    http://*|https://*)
+      url="$1"
+      shift
+      ;;
+    -H)
+      shift 2
+      ;;
+    --retry|--retry-delay)
+      shift 2
+      ;;
+    --retry-connrefused|--fail|--silent|--show-error)
+      shift
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$url" ]]; then
+  echo "curl stub: missing URL" >&2
+  exit 1
+fi
+
+page="$(printf '%s' "$url" | sed -n 's/.*[?&]page=\([0-9][0-9]*\).*/\1/p')"
+if [[ -z "$page" ]]; then
+  page=0
+fi
+
+if [[ -n "$fail_on_page" && "$page" == "$fail_on_page" ]]; then
+  echo "curl stub: simulated failure on page $page" >&2
+  exit 22
+fi
+
+fixture="${FIXTURE_DIR}/page${page}.json"
+if [[ ! -f "$fixture" ]]; then
+  echo "curl stub: fixture $fixture not found" >&2
+  exit 1
+fi
+
+cat "$fixture"

--- a/tests/fixtures/expected.csv
+++ b/tests/fixtures/expected.csv
@@ -1,0 +1,4 @@
+"repo name","repo link","entity name","entity description"
+"example/gamma-service","https://github.com/example/gamma-service","gamma-service",""
+"example/one-service","https://github.com/example/one-service","one-service","One service"
+"example/two-service","https://github.com/example/two-service","two-service","Two service"

--- a/tests/fixtures/page0.json
+++ b/tests/fixtures/page0.json
@@ -1,0 +1,23 @@
+{
+  "total": 4,
+  "page": 0,
+  "totalPages": 2,
+  "entities": [
+    {
+      "name": "one-service",
+      "description": "One service",
+      "git": {
+        "repository": "example/one-service",
+        "repositoryUrl": "https://github.com/example/one-service"
+      }
+    },
+    {
+      "name": "two-service",
+      "description": "Two service",
+      "git": {
+        "repository": "example/two-service",
+        "repositoryUrl": "https://github.com/example/two-service"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/page1.json
+++ b/tests/fixtures/page1.json
@@ -1,0 +1,23 @@
+{
+  "total": 4,
+  "page": 1,
+  "totalPages": 2,
+  "entities": [
+    {
+      "name": "two-service",
+      "description": "Two service",
+      "git": {
+        "repository": "example/two-service",
+        "repositoryUrl": "https://github.com/example/two-service"
+      }
+    },
+    {
+      "name": "gamma-service",
+      "description": null,
+      "git": {
+        "provider": "github",
+        "repository": "example/gamma-service"
+      }
+    }
+  ]
+}

--- a/tests/list-cortex-repositories.bats
+++ b/tests/list-cortex-repositories.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+  PATH="${REPO_ROOT}/tests/bin:${PATH}"
+  export PATH
+  export CORTEX_API_TOKEN="test-token"
+  OUTPUT_FILE="${BATS_TMPDIR}/output.csv"
+}
+
+teardown() {
+  rm -f "${OUTPUT_FILE:-}"
+  unset CURL_STUB_FAIL_ON_PAGE
+}
+
+@test "shows usage help" {
+  run "${REPO_ROOT}/list-cortex-repositories" -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "exports repositories to csv using fixtures" {
+  run "${REPO_ROOT}/list-cortex-repositories" \
+    -o sample-team \
+    -u "https://example.test/catalog" \
+    -f "$OUTPUT_FILE" \
+    -q
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Success: Wrote"* ]]
+
+  expected="${REPO_ROOT}/tests/fixtures/expected.csv"
+  if ! cmp -s "$expected" "$OUTPUT_FILE"; then
+    diff -u "$expected" "$OUTPUT_FILE" >&2 || true
+    echo "CSV output did not match expected fixture" >&2
+    return 1
+  fi
+}
+
+@test "fails when an option argument is missing" {
+  run "${REPO_ROOT}/list-cortex-repositories" -o
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Error: Option -o requires an argument."* ]]
+}
+
+@test "surfaces curl failures" {
+  export CURL_STUB_FAIL_ON_PAGE=1
+  run "${REPO_ROOT}/list-cortex-repositories" \
+    -o sample-team \
+    -u "https://example.test/catalog" \
+    -f "$OUTPUT_FILE" \
+    -q
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Error: Failed to fetch page 1 from Cortex API."* ]]
+}


### PR DESCRIPTION
## What?

Add a repeatable test suite for `list-cortex-repositories`, a CI workflow, and a `make test` target so the checks are easy to run locally.

## Why?

Provide confidence in the script’s option parsing and CSV export logic while making it straightforward to run the same checks in GitHub Actions.

## Changes:

- Add bats-based tests with fixture data and a stub `curl` so no real Cortex token is required.
- Introduce `.github/workflows/ci.yml` to run shellcheck and the bats suite on pushes and pull requests.
- Extend the Makefile and README with testing documentation and dependencies.

## References:

- None
