### PR TITLE
[NO-JIRA]: cancel concurrent workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What?

Introduce concurrency configuration so runs for the same workflow and reference cancel in-progress executions.

## Why?

Prevent wasted runner time by ensuring only the most recent push continues running.

## Changes:

- add a concurrency group keyed by workflow name and Git reference
- enable automatic cancellation of in-progress runs in that group
